### PR TITLE
Add Python 3 compatibility

### DIFF
--- a/zotero_cli/backend.py
+++ b/zotero_cli/backend.py
@@ -5,9 +5,19 @@ import re
 import tempfile
 import time
 import urllib
-import urlparse
+try:
+    import urlparse
+except ImportError:
+    import urllib.parse as urlparse
+try:
+    urlencode = urllib.urlencode
+except AttributeError:
+    urlencode = urlparse.urlencode
 import zipfile
-from cStringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 
 import click
@@ -64,7 +74,7 @@ class ZoteroBackend(object):
         token, secret = auth.get_request_token(
             params={'oauth_callback': 'oob'})
         auth_url = auth.get_authorize_url(token)
-        auth_url += '&' + urllib.urlencode({
+        auth_url += '&' + urlencode({
             'name': 'zotero-cli',
             'library_access': 1,
             'notes_access': 1,
@@ -112,7 +122,7 @@ class ZoteroBackend(object):
         self._index = SearchIndex(idx_path)
         sync_interval = self.config.get('zotcli.sync_interval', 300)
         since_last_sync = int(time.time()) - self._index.last_modified
-        if since_last_sync >= sync_interval:
+        if since_last_sync >= int(sync_interval):
             self._logger.info("{} seconds since last sync, synchronizing."
                               .format(since_last_sync))
             self.synchronize()

--- a/zotero_cli/common.py
+++ b/zotero_cli/common.py
@@ -9,7 +9,6 @@ except NameError:
     unicode = lambda s: str(s)
 from collections import namedtuple
 
-
 import click
 
 APP_NAME = "zotcli"

--- a/zotero_cli/common.py
+++ b/zotero_cli/common.py
@@ -1,6 +1,14 @@
 import os
-import ConfigParser
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
+try:
+    UNICODE_EXISTS = bool(type(unicode))
+except NameError:
+    unicode = lambda s: str(s)
 from collections import namedtuple
+
 
 import click
 
@@ -24,7 +32,7 @@ def load_config():
         raise ValueError("Could not find configuration file. Please run "
                          "`zotcli configure` to perform the first-time "
                          "setup.")
-    parser = ConfigParser.RawConfigParser()
+    parser = configparser.RawConfigParser()
     parser.read([cfg_path])
     rv = {}
     for section in parser.sections():
@@ -43,7 +51,7 @@ def save_config(cfgdata):
     cfg_dir = os.path.dirname(cfg_path)
     if not os.path.exists(cfg_dir):
         os.makedirs(cfg_dir)
-    cfg = ConfigParser.SafeConfigParser()
+    cfg = configparser.SafeConfigParser()
     cfg.add_section("zotcli")
     for key, value in cfgdata.items():
         cfg.set("zotcli", key, unicode(value))


### PR DESCRIPTION
After `pip install zotero-cli` on a Python 3 system, the command `zotcli` fails due to module renames from 2->3. The command `zotcli configure` also fails due to Unicode changes in Python 3.

I added boilerplate so that this tool should work on Python 2 and Python 3 alike. Let me know if you'd like any changes.