### PR TITLE
Fix note save at exception

### DIFF
--- a/zotero_cli/backend.py
+++ b/zotero_cli/backend.py
@@ -335,7 +335,7 @@ class ZoteroBackend(object):
         except Exception as e:
             self._logger.error(e)
             with open("note_backup.txt", "w") as fp:
-                fp.write(raw_data['text'])
+                fp.write(raw_data['text'].encode('utf-8'))
             self._logger.warn(
                 "Could not upload note to Zotero. You can find the note "
                 "markup in 'note_backup.txt' in the current directory")

--- a/zotero_cli/backend.py
+++ b/zotero_cli/backend.py
@@ -317,7 +317,7 @@ class ZoteroBackend(object):
         except Exception as e:
             self._logger.error(e)
             with open("note_backup.txt", "w") as fp:
-                fp.write(note_data)
+                fp.write(raw_data['text'].encode('utf-8'))
             self._logger.warn(
                 "Could not upload note to Zotero. You can find the note "
                 "markup in 'note_backup.txt' in the current directory")

--- a/zotero_cli/backend.py
+++ b/zotero_cli/backend.py
@@ -335,7 +335,7 @@ class ZoteroBackend(object):
         except Exception as e:
             self._logger.error(e)
             with open("note_backup.txt", "w") as fp:
-                fp.write(raw_data)
+                fp.write(raw_data['text'])
             self._logger.warn(
                 "Could not upload note to Zotero. You can find the note "
                 "markup in 'note_backup.txt' in the current directory")


### PR DESCRIPTION
Currently if the note was remotely changed, before the local edit was completed, the program crashes before creating the backup file, as the raw_data map cannot be passed to file.write(); this PR fixes that problem.