### PR TITLE
find_storage_directories: prevent crash with nonexistent directories

### DIFF
--- a/zotero_cli/cli.py
+++ b/zotero_cli/cli.py
@@ -39,16 +39,21 @@ def find_storage_directories():
     home_dir = pathlib.Path(os.environ['HOME'])
     firefox_dir = home_dir/".mozilla"/"firefox"
     zotero_dir = home_dir/".zotero"
-    candidate_iter = itertools.chain(firefox_dir.iterdir(),
-                                     zotero_dir.iterdir())
-    for fpath in candidate_iter:
+
+    osx_support_dir = home_dir/"Library"/"Application Support"
+    zotero_osx_dir = osx_support_dir/"Zotero"/"Profiles"
+
+    candidates = [firefox_dir, zotero_dir, zotero_osx_dir]
+    for fpath in candidates:
         if not fpath.is_dir():
             continue
-        match = PROFILE_PAT.match(fpath.name)
-        if match:
-            storage_path = fpath/"zotero"/"storage"
-            if storage_path.exists():
-                yield (match.group(2), storage_path)
+
+        for subdir in fpath.iterdir():
+            match = PROFILE_PAT.match(subdir.name)
+            if match:
+                storage_path = subdir/"zotero"/"storage"
+                if storage_path.exists():
+                    yield (match.group(2), storage_path)
 
 
 @click.group(context_settings={'help_option_names': ['-h', '--help']})


### PR DESCRIPTION
I ran `zotcli configure` on OS X using the pip-distributed package and got the following error:

```
$ zotcli configure
Do you already have an API key for zotero-cli? [y/N]: n
Opening ...
Enter verification code: ...
[0] Local Zotero storage
[1] Use Zotero file cloud
[2] Use WebDAV storage
How do you want to access files for reading? [1]: 0
Traceback (most recent call last):
  File "/Users/jon/anaconda/bin/zotcli", line 11, in <module>
    load_entry_point('zotero-cli==0.3.0', 'console_scripts', 'zotcli')()
  File "/Users/jon/anaconda/lib/python3.5/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/Users/jon/anaconda/lib/python3.5/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/Users/jon/anaconda/lib/python3.5/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/jon/anaconda/lib/python3.5/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/jon/anaconda/lib/python3.5/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/Users/jon/anaconda/lib/python3.5/site-packages/zotero_cli/cli.py", line 91, in configure
    storage_dirs = tuple(find_storage_directories())
  File "/Users/jon/anaconda/lib/python3.5/site-packages/zotero_cli/cli.py", line 44, in find_storage_directories
    for fpath in candidate_iter:
  File "/Users/jon/anaconda/lib/python3.5/pathlib.py", line 1049, in iterdir
    for name in self._accessor.listdir(self):
  File "/Users/jon/anaconda/lib/python3.5/pathlib.py", line 371, in wrapped
    return strfunc(str(pathobj), *args)
FileNotFoundError: [Errno 2] No such file or directory: '/Users/jon/.mozilla/firefox'
```

This PR prevents this crash and adds support for the OS X Zotero profile directory.
Thanks for making this package!