### PR TITLE
Ugly workaround for the missing regexes

### DIFF
--- a/zotero_cli/backend.py
+++ b/zotero_cli/backend.py
@@ -271,7 +271,10 @@ class ZoteroBackend(object):
         data = None
         note_html = note_data['data']['note']
         note_version = note_data['version']
-        blobs = DATA_PAT.findall(note_html)
+        # This is temporary and _very_ ugly
+        blobs = [codecs.unicode_escape_decode(re.compile('title=.*n\'\">')
+            .findall(note_html)[0][9:-3])[0].encode('utf8')]
+        #blobs = DATA_PAT.findall(note_html)
         # Previously edited with zotcli
         if blobs:
             data = decode_blob(blobs[0])


### PR DESCRIPTION
I'm not familiar with regexes, I just wanted to highlight this problem. For me, no notes are being detected as previously edited with zotcli using the current regex. I had to change it to what is shown below, maybe you can figure out what is going on and make a permanent fix? Related to #21 