### PR TITLE
Query the abstract in addition to the title and authors

### DIFF
--- a/zotero_cli/backend.py
+++ b/zotero_cli/backend.py
@@ -198,6 +198,7 @@ class ZoteroBackend(object):
                 yield Item(key=it['data']['key'],
                            creator=it['meta'].get('creatorSummary'),
                            title=it['data'].get('title', "Untitled"),
+                           abstract=it['data'].get('abstractNote'),
                            date=it['data'].get('date'),
                            citekey=citekey)
 

--- a/zotero_cli/common.py
+++ b/zotero_cli/common.py
@@ -13,7 +13,7 @@ import click
 
 APP_NAME = "zotcli"
 
-Item = namedtuple("Item", ("key", "creator", "title", "date", "citekey"))
+Item = namedtuple("Item", ("key", "creator", "title", "abstract", "date", "citekey"))
 
 
 def _get_config_path():

--- a/zotero_cli/index.py
+++ b/zotero_cli/index.py
@@ -12,16 +12,17 @@ SCHEMA = """
         version     INTEGER
     );
     CREATE TABLE IF NOT EXISTS items (
-        id      INTEGER PRIMARY KEY,
-        key     TEXT UNIQUE,
-        creator TEXT,
-        title   TEXT,
-        date    TEXT,
-        citekey TEXT UNIQUE
+        id          INTEGER PRIMARY KEY,
+        key         TEXT UNIQUE,
+        creator     TEXT,
+        title       TEXT,
+        abstract    TEXT,
+        date        TEXT,
+        citekey     TEXT UNIQUE
     );
 
     CREATE VIRTUAL TABLE items_idx USING fts4(
-        key, creator, title, date, citekey,
+        key, creator, title, abstract, date, citekey,
         content="items");
     CREATE VIRTUAL TABLE items_idx_terms USING fts4aux(items_idx);
 
@@ -33,25 +34,25 @@ SCHEMA = """
     END;
 
     CREATE TRIGGER items_au AFTER UPDATE ON items BEGIN
-        INSERT INTO items_idx(docid, key, creator, title, date, citekey)
-            VALUES(new.rowid, new.key, new.creator, new.title, new.date,
+        INSERT INTO items_idx(docid, key, creator, title, abstract, date, citekey)
+            VALUES(new.rowid, new.key, new.creator, new.title, new.abstract, new.date,
                    new.citekey);
     END;
     CREATE TRIGGER items_ai AFTER INSERT ON items BEGIN
-        INSERT INTO items_idx(docid, key, creator, title, date, citekey)
-            VALUES(new.rowid, new.key, new.creator, new.title, new.date,
+        INSERT INTO items_idx(docid, key, creator, title, abstract, date, citekey)
+            VALUES(new.rowid, new.key, new.creator, new.title, new.abstract, new.date,
                    new.citekey);
     END;
 """
 SEARCH_QUERY = """
-    SELECT items.key, creator, title, date, citekey FROM items JOIN (
+    SELECT items.key, creator, title, abstract, date, citekey FROM items JOIN (
         SELECT key FROM items_idx
         WHERE items_idx MATCH :query) AS idx ON idx.key = items.key
         LIMIT :limit;
 """
 INSERT_ITEMS_QUERY = """
-    INSERT OR REPLACE INTO items (key, creator, title, date, citekey)
-        VALUES (:key, :creator, :title, :date, :citekey);
+    INSERT OR REPLACE INTO items (key, creator, title, abstract, date, citekey)
+        VALUES (:key, :creator, :title, :abstract, :date, :citekey);
 """
 INSERT_META_QUERY = """
     INSERT OR REPLACE INTO syncinfo (id, last_sync, version)


### PR DESCRIPTION
This seems to work fine, at least to initially enable the abstract query functionality and close #20 (full text search can be made a separate issue, if needed). An extension could be  to have some way of limiting the query to a subset of title, authors, and abstract.

I tested a handful of queries in terms of speed between retrieving from a database with and without abstracts. There was no noticeable difference, queries took around 0.55 - 0.65 s in almost all cases.

For my library of ~500 items, the `index.sqlite` database is about 5x bigger with abstract. It went from 244K to 1.3M.